### PR TITLE
Fix Dependabot for Bun lockfile updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
 version: 2
 updates:
-  - package-ecosystem: npm
+  # Bun workspaces: use the bun ecosystem so Dependabot updates bun.lock
+  # alongside package.json. The npm ecosystem only bumps manifests and
+  # breaks CI's `bun install --frozen-lockfile` step.
+  - package-ecosystem: bun
     directory: /
     schedule:
       interval: weekly
@@ -10,6 +13,12 @@ updates:
         dependency-type: production
       development-dependencies:
         dependency-type: development
+    ignore:
+      # Major dev-tool bumps (TypeScript, Vitest, Vite plugins) need a
+      # deliberate upgrade pass, not a grouped Dependabot PR.
+      - dependency-name: "*"
+        dependency-type: development
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary
- Switch Dependabot from `npm` to `bun` so `bun.lock` is updated alongside workspace `package.json` files
- Ignore semver-major dev dependency bumps (TypeScript, Vitest, Vite plugins, etc.) — those need a deliberate upgrade, not a grouped PR

## Why
PR #4 failed CI with `lockfile had changes, but lockfile is frozen` because Dependabot only bumped `package.json` files and left `bun.lock` stale.

## Test plan
- [ ] Merge and close PR #4 (superseded / unsafe major bumps)
- [ ] Wait for next Dependabot run and confirm new PRs include `bun.lock`

Made with [Cursor](https://cursor.com)