### PR TITLE
Show active query in Composer thinking demos

### DIFF
--- a/apps/docs/src/components/demos/ComposerDemo.tsx
+++ b/apps/docs/src/components/demos/ComposerDemo.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Button, Composer } from "@kernelui-lib/react";
 
 export default function ComposerDemo() {
+  const [value, setValue] = useState("");
   const [thinking, setThinking] = useState(false);
 
   function handleSubmit() {
@@ -12,6 +13,8 @@ export default function ComposerDemo() {
   return (
     <Composer
       placeholder="Ask anything…"
+      value={value}
+      onValueChange={setValue}
       thinking={thinking}
       onSubmit={handleSubmit}
       actionsTrailing={({ submit }) => (

--- a/apps/docs/src/components/demos/ComposerPlayground.tsx
+++ b/apps/docs/src/components/demos/ComposerPlayground.tsx
@@ -1,5 +1,6 @@
 import { Composer } from "@kernelui-lib/react";
 import Playground, { type PlaygroundValues } from "../Playground";
+import { EXAMPLE_QUERY } from "./ComposerThinkingExample";
 
 const controls = [
   { type: "text" as const, prop: "placeholder", default: "Ask anything…" },
@@ -16,7 +17,10 @@ const controls = [
 function code(values: PlaygroundValues) {
   const attrs: string[] = [`placeholder="${values.placeholder}"`];
   if (values.submitOn !== "mod+enter") attrs.push(`submitOn="${values.submitOn}"`);
-  if (values.thinking) attrs.push("thinking");
+  if (values.thinking) {
+    attrs.push("thinking");
+    attrs.push(`defaultValue="${EXAMPLE_QUERY}"`);
+  }
   if (values.disabled) attrs.push("disabled");
   return `<Composer ${attrs.join(" ")} />`;
 }
@@ -24,7 +28,10 @@ function code(values: PlaygroundValues) {
 function elementsCode(values: PlaygroundValues) {
   const attrs: string[] = [`placeholder="${values.placeholder}"`];
   if (values.submitOn !== "mod+enter") attrs.push(`submit-on="${values.submitOn}"`);
-  if (values.thinking) attrs.push("thinking");
+  if (values.thinking) {
+    attrs.push("thinking");
+    attrs.push(`value="${EXAMPLE_QUERY}"`);
+  }
   if (values.disabled) attrs.push("disabled");
   return `<kernel-composer ${attrs.join(" ")}></kernel-composer>`;
 }
@@ -37,8 +44,10 @@ export default function ComposerPlayground() {
       elementsCode={elementsCode}
       render={(values) => (
         <Composer
+          key={values.thinking ? "thinking" : "idle"}
           placeholder={String(values.placeholder)}
           submitOn={values.submitOn as "mod+enter" | "enter"}
+          defaultValue={values.thinking ? EXAMPLE_QUERY : ""}
           thinking={Boolean(values.thinking)}
           disabled={Boolean(values.disabled)}
         />

--- a/apps/docs/src/components/demos/ComposerThinkingExample.tsx
+++ b/apps/docs/src/components/demos/ComposerThinkingExample.tsx
@@ -1,0 +1,11 @@
+import { Composer } from "@kernelui-lib/react";
+
+const EXAMPLE_QUERY = "How do I theme Kernel with a custom accent colour?";
+
+export default function ComposerThinkingExample() {
+  return (
+    <Composer placeholder="Ask anything…" defaultValue={EXAMPLE_QUERY} thinking />
+  );
+}
+
+export { EXAMPLE_QUERY };

--- a/apps/docs/src/pages/components/composer.astro
+++ b/apps/docs/src/pages/components/composer.astro
@@ -5,6 +5,7 @@ import ExampleGrid from "../../components/ExampleGrid.astro";
 import Example from "../../components/Example.astro";
 import ComposerDemo from "../../components/demos/ComposerDemo";
 import ComposerActionsExample from "../../components/demos/ComposerActionsExample";
+import ComposerThinkingExample from "../../components/demos/ComposerThinkingExample";
 import ComposerPlayground from "../../components/demos/ComposerPlayground";
 import { Composer } from "@kernelui-lib/react";
 
@@ -22,7 +23,11 @@ const actionsSnippet = `<Composer
   )}
 />`;
 
-const thinkingSnippet = `<Composer placeholder="Ask anything…" thinking />`;
+const thinkingSnippet = `<Composer
+  placeholder="Ask anything…"
+  defaultValue="How do I theme Kernel with a custom accent colour?"
+  thinking
+/>`;
 ---
 
 <BaseLayout title="Composer" withSidebar>
@@ -55,10 +60,10 @@ const thinkingSnippet = `<Composer placeholder="Ask anything…" thinking />`;
       </Example>
       <Example
         title="Thinking state"
-        description="An animated border sweep signals an in-flight response and blocks submission."
+        description="An animated border sweep signals an in-flight response and blocks submission. The submitted query stays visible."
         code={thinkingSnippet}
       >
-        <Composer placeholder="Ask anything…" thinking />
+        <ComposerThinkingExample client:load />
       </Example>
     </ExampleGrid>
 

--- a/apps/docs/src/pages/labs/elements.astro
+++ b/apps/docs/src/pages/labs/elements.astro
@@ -157,7 +157,11 @@ import "@kernelui-lib/elements/styles.css";
 
     <kernel-thinking-indicator id="lab-thinking"></kernel-thinking-indicator>
 
-    <kernel-composer id="lab-composer" placeholder="Ask anything…">
+    <kernel-composer
+      id="lab-composer"
+      placeholder="Ask anything…"
+      value="How do I theme Kernel with a custom accent colour?"
+    >
       <kernel-button id="lab-composer-send" slot="trailing" variant="primary" size="sm">Send</kernel-button>
     </kernel-composer>
     <kernel-button id="lab-composer-thinking-toggle" variant="secondary" size="sm">


### PR DESCRIPTION
## Summary
- Add a thinking-state example with a realistic submitted query
- Keep the query visible during thinking in the interactive demo (controlled value)
- Pre-fill the playground and elements lab when thinking is on

## Test plan
- [ ] Open `/components/composer/` and check the Thinking state example
- [ ] Submit a message in the top demo and confirm text stays during thinking

Made with [Cursor](https://cursor.com)