### PR TITLE
Fix Dependabot bun config validation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,13 +11,28 @@ updates:
     groups:
       production-dependencies:
         dependency-type: production
-      development-dependencies:
-        dependency-type: development
+      # Bun only supports dependency-type production|runtime in groups, not
+      # development — match dev tools by name instead.
+      dev-dependencies:
+        patterns:
+          - "@types/*"
+          - "@astrojs/*"
+          - "@vitejs/*"
+          - "typescript"
+          - "vitest"
+          - "vite*"
+          - "jsdom"
     ignore:
-      # Major dev-tool bumps (TypeScript, Vitest, Vite plugins) need a
-      # deliberate upgrade pass, not a grouped Dependabot PR.
-      - dependency-name: "*"
-        dependency-type: development
+      # Major dev-tool bumps need a deliberate upgrade pass.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "vitest"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "jsdom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@vitejs/plugin-react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "vite-plugin-dts"
         update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Summary
Dependabot rejected `.github/dependabot.yml` because the `bun` ecosystem does not support `dependency-type: development` in groups (only `production` and `runtime`).

- Keep `production-dependencies` grouped by `dependency-type: production`
- Group dev tools by `patterns` instead
- Ignore semver-major bumps for TypeScript, Vitest, Vite plugins, and jsdom explicitly

## Test plan
- [ ] Dependabot insights shows a valid config (no parse error)
- [ ] Next weekly run opens PRs with `bun.lock` updates

Made with [Cursor](https://cursor.com)