### PR TITLE
Fix homepage meta title and og:site_name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ package-lock.json
 yarn.lock
 examples/**/node_modules
 examples/**/dist
+.vercel
+.vercel

--- a/apps/docs/src/layouts/BaseLayout.astro
+++ b/apps/docs/src/layouts/BaseLayout.astro
@@ -9,7 +9,7 @@ import MobileNav from "../components/MobileNav";
 import DocsSidebarNav from "../components/DocsSidebarNav.astro";
 import TableOfContents from "../components/TableOfContents.astro";
 import { components } from "../data/components";
-import { SITE_URL } from "../lib/site";
+import { SITE_URL, SITE_NAME, SITE_DEFAULT_TITLE, SITE_DEFAULT_DESCRIPTION } from "../lib/site";
 
 interface Props {
   title: string;
@@ -32,11 +32,12 @@ const description =
   descriptionProp ??
   (componentEntry
     ? `${componentEntry.summary} Built on ${componentEntry.element}.`
-    : "A component library built on the actual kernel of the web: real semantic HTML, not div soup.");
+    : SITE_DEFAULT_DESCRIPTION);
 
 const canonicalUrl = new URL(Astro.url.pathname, SITE_URL).href;
 const ogImage = new URL("/og.png", SITE_URL).href;
-const pageTitle = Astro.url.pathname === "/" ? "Kernel" : `${title} · Kernel`;
+const pageTitle =
+  Astro.url.pathname === "/" ? SITE_DEFAULT_TITLE : `${title} — ${SITE_NAME}`;
 ---
 
 <!doctype html>
@@ -148,6 +149,7 @@ const pageTitle = Astro.url.pathname === "/" ? "Kernel" : `${title} · Kernel`;
     <meta name="description" content={description} />
     <meta property="og:title" content={pageTitle} />
     <meta property="og:description" content={description} />
+    <meta property="og:site_name" content={SITE_NAME} />
     <meta property="og:image" content={ogImage} />
     <meta property="og:url" content={canonicalUrl} />
     <meta property="og:type" content="website" />

--- a/apps/docs/src/lib/site.ts
+++ b/apps/docs/src/lib/site.ts
@@ -1,5 +1,14 @@
 export const SITE_URL = "https://www.kernelui.com";
 
+export const SITE_NAME = "Kernel";
+
+/** Homepage `<title>` / `og:title` — aim for ~50–60 characters for SERP and social cards. */
+export const SITE_DEFAULT_TITLE =
+  "Kernel — Semantic HTML components for React and Web Components";
+
+export const SITE_DEFAULT_DESCRIPTION =
+  "A component library built on the actual kernel of the web: real semantic HTML, not div soup.";
+
 export const GITHUB_URL = "https://github.com/kemiljk/kernel-ui";
 
 export const NPM_REACT_URL = "https://www.npmjs.com/package/@kernelui-lib/react";


### PR DESCRIPTION
## Summary
- Homepage `<title>` / `og:title` is now ~61 characters instead of "Kernel" (6)
- Adds `og:site_name` so Discord and similar platforms show the brand above the title
- Gitignores `.vercel` from local `vercel pull`

## Test plan
- [ ] Re-scrape https://www.kernelui.com/ in an OG debugger
- [ ] Confirm title and site name warnings are resolved

Made with [Cursor](https://cursor.com)