### PR TITLE
Add self-hosted Umami analytics tracking

### DIFF
--- a/apps/docs/src/layouts/BaseLayout.astro
+++ b/apps/docs/src/layouts/BaseLayout.astro
@@ -163,6 +163,16 @@ const pageTitle =
          no page CSS context, so a theme-reactive colour would just never
          resolve and fall back to nothing. -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    {
+      import.meta.env.PROD && (
+        <script
+          is:inline
+          defer
+          src="https://analytics.karlkoch.me/script.js"
+          data-website-id="f4ad2f0d-e314-4dca-a2db-e120ab282e4b"
+        />
+      )
+    }
     <ClientRouter />
     <!--
       The sidebar below is transition:persist'd across navigations —


### PR DESCRIPTION
## Summary
- Adds the self-hosted Umami tracking script to `BaseLayout.astro`, which every page in the docs app renders through
- Gated behind `import.meta.env.PROD` so local dev traffic is never tracked
- Points at `https://analytics.karlkoch.me/script.js` with site ID `f4ad2f0d-e314-4dca-a2db-e120ab282e4b`

## Why
No analytics were wired up for the docs site. Umami's default script patches `history.pushState`/`popstate`, so it also picks up Astro's `ClientRouter` soft navigations automatically — no extra event wiring needed.

## Test plan
- [x] `bun run astro check` — 0 errors, 0 warnings, 0 hints
- [x] Deploy preview and confirm a pageview shows up in the Umami dashboard for `f4ad2f0d-e314-4dca-a2db-e120ab282e4b`