### PR TITLE
Add composable search primitives

### DIFF
--- a/apps/docs/src/components/demos/ComboboxCompositionDemo.tsx
+++ b/apps/docs/src/components/demos/ComboboxCompositionDemo.tsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import { Combobox } from "@kernelui-lib/react";
+
+const groups = [
+  { id: "frontend", label: "Frontend", items: [{ value: "astro", label: "Astro" }, { value: "react", label: "React" }] },
+  { id: "backend", label: "Backend", items: [{ value: "bun", label: "Bun" }, { value: "node", label: "Node.js" }] },
+];
+
+export default function ComboboxCompositionDemo() {
+  const [value, setValue] = useState("");
+
+  return (
+    <div style={{ maxInlineSize: "22rem" }}>
+      <Combobox label="Framework">
+        <Combobox.Input value={value} onValueChange={setValue} placeholder="Search frameworks" />
+        <Combobox.List>
+          {groups.map((group) => (
+            <Combobox.Group key={group.id} id={group.id} heading={group.label}>
+              {group.items.map((option) => (
+                <Combobox.Item key={option.value} id={`framework-${option.value}`} value={option.value} onSelect={() => setValue(option.label)}>
+                  {({ active, selected }) => (
+                    <span style={{ display: "flex", justifyContent: "space-between", fontWeight: active ? 650 : undefined }}>
+                      {option.label}
+                      {selected ? <span aria-hidden="true">Selected</span> : null}
+                    </span>
+                  )}
+                </Combobox.Item>
+              ))}
+            </Combobox.Group>
+          ))}
+        </Combobox.List>
+      </Combobox>
+    </div>
+  );
+}

--- a/apps/docs/src/components/demos/CommandPaletteCompositionDemo.tsx
+++ b/apps/docs/src/components/demos/CommandPaletteCompositionDemo.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useState } from "react";
+import { Button, CommandPalette } from "@kernelui-lib/react";
+
+type Course = {
+  id: string;
+  track: string;
+  title: string;
+  module: string;
+  status: "Free lesson" | "Completed" | "Premium";
+  sections: Array<{ id: string; label: string; snippet: string }>;
+};
+
+const courses: Course[] = [
+  {
+    id: "flexbox",
+    track: "Layout engineering",
+    title: "Flexbox that holds up under pressure",
+    module: "Module 04: Resilient layout",
+    status: "Free lesson",
+    sections: [
+      { id: "flexbox-axis", label: "The two-axis model", snippet: "Understand how main and cross axes change when direction changes." },
+      { id: "flexbox-gaps", label: "Gaps, not magic margins", snippet: "Use gap to keep spacing predictable as items wrap." },
+    ],
+  },
+  {
+    id: "motion",
+    track: "Interaction craft",
+    title: "Motion that explains the interface",
+    module: "Module 07: Physical feedback",
+    status: "Completed",
+    sections: [
+      { id: "motion-anticipation", label: "Anticipation and release", snippet: "A good transition prepares the eye before the layout changes." },
+    ],
+  },
+  {
+    id: "typography",
+    track: "Interface foundations",
+    title: "Typography as a layout system",
+    module: "Module 02: Type and rhythm",
+    status: "Premium",
+    sections: [],
+  },
+];
+
+function highlight(text: string, query: string) {
+  const normalized = query.trim();
+  if (!normalized) return text;
+  const escaped = normalized.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const expression = new RegExp(`(${escaped})`, "ig");
+  return text.split(expression).map((part, index) =>
+    part.toLowerCase() === normalized.toLowerCase()
+      ? <mark key={`${part}-${index}`}>{part}</mark>
+      : part,
+  );
+}
+
+function LessonRow({ course, active }: { course: Course; active: boolean }) {
+  return (
+    <div style={{ display: "grid", gap: "0.2rem", opacity: active ? 1 : 0.88 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: "1rem", alignItems: "baseline" }}>
+        <strong>{course.title}</strong>
+        <small style={{ color: "var(--kernel-color-text-muted)", whiteSpace: "nowrap" }}>{course.status}</small>
+      </div>
+      <span style={{ color: "var(--kernel-color-text-muted)" }}>{course.module}</span>
+    </div>
+  );
+}
+
+function SectionRow({ section, query, active }: { section: Course["sections"][number]; query: string; active: boolean }) {
+  return (
+    <div style={{ display: "grid", gap: "0.2rem", paddingInlineStart: "1rem", borderInlineStart: "2px solid var(--kernel-color-border)" }}>
+      <strong style={{ fontWeight: active ? 650 : 550 }}>{section.label}</strong>
+      <span style={{ color: "var(--kernel-color-text-muted)" }}>{highlight(section.snippet, query)}</span>
+    </div>
+  );
+}
+
+export default function CommandPaletteCompositionDemo() {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [offline, setOffline] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [visibleCourses, setVisibleCourses] = useState(courses);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    const timer = window.setTimeout(() => {
+      const normalized = query.trim().toLowerCase();
+      setVisibleCourses(normalized
+        ? courses.filter((course) => {
+            const courseText = `${course.title} ${course.module} ${course.track} ${course.sections.map((section) => `${section.label} ${section.snippet}`).join(" ")}`;
+            return courseText.toLowerCase().includes(normalized);
+          })
+        : courses);
+      setLoading(false);
+    }, 280);
+    return () => window.clearTimeout(timer);
+  }, [open, query]);
+
+  return (
+    <div style={{ display: "grid", gap: "1.5rem" }}>
+      <section aria-labelledby="course-search-title" style={{ display: "grid", gap: "0.75rem" }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "end", gap: "1rem", flexWrap: "wrap" }}>
+          <div>
+            <h3 id="course-search-title" style={{ margin: 0 }}>Course search</h3>
+            <p style={{ margin: "0.25rem 0 0", color: "var(--kernel-color-text-muted)" }}>Find a lesson or jump straight to a matching section.</p>
+          </div>
+          <Button variant="primary" onClick={() => setOpen(true)}>Search the course</Button>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: "0.5rem", flexWrap: "wrap", color: "var(--kernel-color-text-muted)", fontSize: "0.875rem" }}>
+          <span>{visibleCourses.length} lessons indexed</span>
+          <span aria-hidden="true">·</span>
+          <Button variant="ghost" size="sm" onClick={() => setOffline((current) => !current)} aria-pressed={offline}>{offline ? "Reconnect search" : "Simulate offline"}</Button>
+          {selected ? <output role="status">Opened: {selected}</output> : null}
+        </div>
+      </section>
+
+      <CommandPalette open={open} onOpenChange={setOpen} shouldFilter={false}>
+        <CommandPalette.Input value={query} onValueChange={setQuery} placeholder="Search lessons and sections" />
+        <CommandPalette.List>
+          {loading ? <CommandPalette.Loading>Searching the course index...</CommandPalette.Loading> : null}
+          {!loading && offline ? <CommandPalette.Empty>Unable to load lessons. Reconnect search and try again.</CommandPalette.Empty> : null}
+          {!loading && !offline && visibleCourses.length === 0 ? <CommandPalette.Empty>No lessons match &quot;{query}&quot;. Try a broader search.</CommandPalette.Empty> : null}
+          {!loading && !offline ? visibleCourses.map((course) => (
+            <CommandPalette.Group key={course.id} id={course.id} heading={course.track}>
+              <CommandPalette.Item id={`lesson-${course.id}`} value={`${course.title} ${course.module}`} disabled={course.status === "Premium"} onSelect={() => setSelected(course.title)}>
+                {({ active }) => <LessonRow course={course} active={active} />}
+              </CommandPalette.Item>
+              {course.sections.map((section) => (
+                <CommandPalette.Item key={section.id} id={`section-${section.id}`} value={`${section.label} ${section.snippet}`} onSelect={() => setSelected(section.label)}>
+                  {({ active }) => <SectionRow section={section} query={query} active={active} />}
+                </CommandPalette.Item>
+              ))}
+            </CommandPalette.Group>
+          )) : null}
+        </CommandPalette.List>
+      </CommandPalette>
+
+    </div>
+  );
+}

--- a/apps/docs/src/pages/components/combobox.astro
+++ b/apps/docs/src/pages/components/combobox.astro
@@ -5,6 +5,7 @@ import UsageAccordion from "../../components/UsageAccordion.astro";
 import ComboboxDemo from "../../components/demos/ComboboxDemo";
 import ComboboxGroupsDemo from "../../components/demos/ComboboxGroupsDemo";
 import ComboboxPlayground from "../../components/demos/ComboboxPlayground";
+import ComboboxCompositionDemo from "../../components/demos/ComboboxCompositionDemo";
 
 const usageSnippet = `import { useState } from "react";
 import { Combobox } from "@kernelui-lib/react";
@@ -97,6 +98,17 @@ function renderOption(option: ComboboxOption, state: { selected: boolean }) {
     </div>
 
     <UsageAccordion code={groupsSnippet} lang="tsx" />
+
+    <h2>Composable options</h2>
+    <p>
+      Use the compound API when each option needs product-owned markup,
+      active-state styling, or grouped asynchronous results. The same
+      input-focused keyboard and listbox behavior stays in Kernel.
+    </p>
+
+    <div class="docs-example">
+      <ComboboxCompositionDemo client:visible />
+    </div>
 
     <h2>Props</h2>
     <div class="docs-table-scroll"><table class="docs-table">

--- a/apps/docs/src/pages/components/command-palette.astro
+++ b/apps/docs/src/pages/components/command-palette.astro
@@ -5,6 +5,7 @@ import UsageAccordion from "../../components/UsageAccordion.astro";
 import CommandPaletteDemo from "../../components/demos/CommandPaletteDemo";
 import CommandPaletteGroupsDemo from "../../components/demos/CommandPaletteGroupsDemo";
 import CommandPalettePlayground from "../../components/demos/CommandPalettePlayground";
+import CommandPaletteCompositionDemo from "../../components/demos/CommandPaletteCompositionDemo";
 
 const usageSnippet = `import { useState } from "react";
 import { Button, CommandPalette } from "@kernelui-lib/react";
@@ -62,6 +63,26 @@ function App() {
     />
   );
 }`;
+
+const compositionSnippet = `import { CommandPalette, Combobox } from "@kernelui-lib/react";
+
+<CommandPalette open={open} onOpenChange={setOpen} shouldFilter={false}>
+  <CommandPalette.Input value={query} onValueChange={setQuery} />
+  <CommandPalette.List>
+    {isLoading && <CommandPalette.Loading>Searching...</CommandPalette.Loading>}
+    {!isLoading && error && <CommandPalette.Empty>{error}</CommandPalette.Empty>}
+    <CommandPalette.Group heading="Engineering Track">
+      <CommandPalette.Item id="lesson-flexbox" value={lesson.searchText} onSelect={goToLesson}>
+        {({ active }) => <LessonRow lesson={lesson} active={active} />}
+      </CommandPalette.Item>
+      <CommandPalette.Item id="section-flexbox-layout" value={section.searchText} onSelect={goToSection}>
+        {({ active }) => <SectionRow section={section} active={active} />}
+      </CommandPalette.Item>
+    </CommandPalette.Group>
+  </CommandPalette.List>
+</CommandPalette>
+
+`;
 ---
 
 <BaseLayout title="Command Palette" withSidebar>
@@ -109,6 +130,20 @@ function App() {
     </div>
 
     <UsageAccordion code={groupsSnippet} lang="tsx" />
+
+    <h2>Composable async results</h2>
+    <p>
+      The compound API keeps one focused input while your product owns the
+      result model. This example combines controlled query state, external
+      filtering, grouped lesson and section rows, active render state,
+      disabled results, loading, empty, error, and asynchronous replacement.
+    </p>
+
+    <div class="docs-example">
+      <CommandPaletteCompositionDemo client:visible />
+    </div>
+
+    <UsageAccordion code={compositionSnippet} lang="tsx" />
 
     <h2>Props</h2>
     <div class="docs-table-scroll"><table class="docs-table">

--- a/packages/elements/src/components/Checkbox/Checkbox.css
+++ b/packages/elements/src/components/Checkbox/Checkbox.css
@@ -118,6 +118,7 @@
 }
 
 .kernel-Checkbox-label {
+  -webkit-user-select: none;
   user-select: none;
 }
 

--- a/packages/elements/src/components/Combobox/Combobox.css
+++ b/packages/elements/src/components/Combobox/Combobox.css
@@ -100,6 +100,20 @@
   background-color: var(--kernel-color-accent-subtle);
 }
 
+.kernel-Combobox-listbox > [role="group"] + [role="group"] {
+  margin-block-start: var(--kernel-space-3);
+}
+
+.kernel-Combobox-groupLabel {
+  padding-block: var(--kernel-space-2) 0;
+  padding-inline: var(--kernel-space-3);
+  color: var(--kernel-color-text-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .kernel-Combobox-option[aria-selected="true"] {
   font-weight: 600;
 }

--- a/packages/elements/src/components/CommandPalette/CommandPalette.css
+++ b/packages/elements/src/components/CommandPalette/CommandPalette.css
@@ -27,6 +27,8 @@
   /* Command Palette reads as a compact action surface, not a full dialog
     sheet, so it uses the container tier's radius/padding pair to keep
     Round mode from over-inflating edge padding. */
+  /* The fully rounded palette stays compact: 16px on every edge. */
+  --kernel-padding-container-curve: var(--kernel-space-4);
   padding: var(--kernel-padding-container-curve);
   background-color: var(--kernel-color-surface-raised);
   color: var(--kernel-color-text);
@@ -115,8 +117,7 @@
   flex-shrink: 0;
   inline-size: 100%;
   block-size: calc(var(--kernel-space-unit) * 12);
-  border: none;
-  border-block-end: var(--kernel-border-width) solid var(--kernel-color-border);
+  border: var(--kernel-border-width) solid var(--kernel-color-border);
   border-radius: var(--kernel-radius-control);
   background-color: transparent;
   color: var(--kernel-color-text);

--- a/packages/elements/src/components/Sheet/Sheet.css
+++ b/packages/elements/src/components/Sheet/Sheet.css
@@ -93,6 +93,22 @@
   min-block-size: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
+  --kernel-scroll-shadow-top: 0;
+  --kernel-scroll-shadow-bottom: 0;
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    rgb(0 0 0 / calc(1 - 0.92 * var(--kernel-scroll-shadow-top))) 0,
+    #000 2.75rem,
+    #000 calc(100% - 2.75rem),
+    rgb(0 0 0 / calc(1 - 0.92 * var(--kernel-scroll-shadow-bottom))) 100%
+  );
+  mask-image: linear-gradient(
+    to bottom,
+    rgb(0 0 0 / calc(1 - 0.92 * var(--kernel-scroll-shadow-top))) 0,
+    #000 2.75rem,
+    #000 calc(100% - 2.75rem),
+    rgb(0 0 0 / calc(1 - 0.92 * var(--kernel-scroll-shadow-bottom))) 100%
+  );
   -webkit-user-select: text;
   user-select: text;
 

--- a/packages/elements/src/components/Sheet/Sheet.ts
+++ b/packages/elements/src/components/Sheet/Sheet.ts
@@ -68,6 +68,9 @@ const SIDES: readonly SheetSide[] = ["bottom", "top", "left", "right"];
 export class KernelSheet extends KernelDialog {
   private handleElement: HTMLElement | null = null;
   private footerElement: HTMLElement | null = null;
+  private bodyElement: HTMLElement | null = null;
+  private bodyResizeObserver: ResizeObserver | null = null;
+  private bodyScrollHandler: (() => void) | null = null;
   private drag: SheetDragController | null = null;
   private resizeHandler: (() => void) | null = null;
   private reflectingSnap = false;
@@ -129,6 +132,13 @@ export class KernelSheet extends KernelDialog {
     this.drag = null;
     if (this.resizeHandler) window.removeEventListener("resize", this.resizeHandler);
     this.resizeHandler = null;
+    this.bodyResizeObserver?.disconnect();
+    this.bodyResizeObserver = null;
+    if (this.bodyElement && this.bodyScrollHandler) {
+      this.bodyElement.removeEventListener("scroll", this.bodyScrollHandler);
+    }
+    this.bodyElement = null;
+    this.bodyScrollHandler = null;
   }
 
   /** A width limit closes the sheet rather than refusing to open it, so that
@@ -241,14 +251,30 @@ export class KernelSheet extends KernelDialog {
 
     const footerSource = content.querySelector(':scope > [slot="footer"]');
     const body = document.createElement("div");
-    body.className = kernelClass("Sheet", "body");
+    body.className = `${kernelClass("Sheet", "body")} ${kernelClass("ScrollArea")}`;
     body.setAttribute("data-slot", "sheet-body");
+    body.setAttribute("data-edge-shadow", "");
 
     for (const node of Array.from(content.childNodes)) {
       if (node === footerSource || node === this.handleElement) continue;
       body.append(node);
     }
     content.append(body);
+    this.bodyElement = body;
+    const measure = () => {
+      const scrollable = body.scrollHeight - body.clientHeight;
+      const top = scrollable > 0 ? Math.min(body.scrollTop / 48, 1) : 0;
+      const bottom = scrollable > 0 ? Math.min((scrollable - body.scrollTop) / 48, 1) : 0;
+      body.style.setProperty("--kernel-scroll-shadow-top", String(top));
+      body.style.setProperty("--kernel-scroll-shadow-bottom", String(bottom));
+    };
+    this.bodyScrollHandler = measure;
+    body.addEventListener("scroll", measure, { passive: true });
+    if (typeof ResizeObserver !== "undefined") {
+      this.bodyResizeObserver = new ResizeObserver(measure);
+      this.bodyResizeObserver.observe(body);
+    }
+    measure();
 
     if (footerSource) {
       const footer = document.createElement("div");

--- a/packages/react/src/components/Checkbox/Checkbox.module.css
+++ b/packages/react/src/components/Checkbox/Checkbox.module.css
@@ -121,6 +121,7 @@
 }
 
 .label {
+  -webkit-user-select: none;
   user-select: none;
 }
 

--- a/packages/react/src/components/Combobox/Combobox.module.css
+++ b/packages/react/src/components/Combobox/Combobox.module.css
@@ -77,6 +77,10 @@
     scale var(--kernel-duration-exit-fast) var(--kernel-ease-overlay);
 }
 
+.listbox > [role="group"] + [role="group"] {
+  margin-block-start: var(--kernel-space-3);
+}
+
 .listbox:popover-open {
   opacity: 1;
   scale: 1;
@@ -128,9 +132,9 @@
   padding-block: var(--kernel-space-2) 0;
   padding-inline: var(--kernel-space-3);
   color: var(--kernel-color-text-muted);
-  font-size: var(--kernel-font-size-xs);
+  font-size: 0.75rem;
   font-weight: 600;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 

--- a/packages/react/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react/src/components/Combobox/Combobox.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { Combobox } from "./Combobox";
+
+describe("Combobox compound API", () => {
+  it("keeps focus on the input while navigating rich grouped options", async () => {
+    render(
+      <Combobox label="Course" shouldFilter={false}>
+        <Combobox.Input aria-label="Search course" />
+        <Combobox.List>
+          <Combobox.Group heading="Track">
+            <Combobox.Item id="lesson" value="lesson">Lesson row</Combobox.Item>
+            <Combobox.Item id="section" value="section">Section row</Combobox.Item>
+          </Combobox.Group>
+          <Combobox.Loading>Searching...</Combobox.Loading>
+        </Combobox.List>
+      </Combobox>,
+    );
+
+    const input = screen.getByRole("combobox", { name: "Search course" });
+    input.focus();
+    await waitFor(() => expect(input).toHaveAttribute("aria-activedescendant", "lesson"));
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(input).toHaveAttribute("aria-activedescendant", "section");
+    expect(document.activeElement).toBe(input);
+    expect(screen.getByRole("status")).toHaveTextContent("Searching...");
+  });
+
+  it("keeps externally controlled query values in sync", async () => {
+    function Example() {
+      const [query, setQuery] = useState("");
+      return (
+        <Combobox label="Course" shouldFilter={false}>
+          <Combobox.Input value={query} onValueChange={setQuery} aria-label="Search" />
+          <Combobox.List><Combobox.Item id="one" value="one">One</Combobox.Item></Combobox.List>
+        </Combobox>
+      );
+    }
+
+    render(<Example />);
+    const input = screen.getByRole("combobox", { name: "Search" });
+    fireEvent.change(input, { target: { value: "async query" } });
+    await waitFor(() => expect(input).toHaveValue("async query"));
+  });
+});

--- a/packages/react/src/components/Combobox/Combobox.tsx
+++ b/packages/react/src/components/Combobox/Combobox.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useId, useMemo, useRef, useState } from "react";
-import type { KeyboardEvent, ReactNode } from "react";
+import { createContext, useCallback, useContext, useEffect, useId, useMemo, useRef, useState } from "react";
+import type { InputHTMLAttributes, KeyboardEvent, ReactNode } from "react";
 import { dataAttr, mergeRefs } from "../../utils/polymorphic";
 import { useControllableState } from "../../utils/useControllableState";
 import {
@@ -37,6 +37,7 @@ export interface ComboboxProps {
   onValueChange?: (value: string) => void;
   placeholder?: string;
   emptyMessage?: ReactNode;
+  shouldFilter?: boolean;
   /** Which side of the field the listbox opens on. */
   placement?: FloatingPlacement;
   /** Cross-axis alignment relative to the field. */
@@ -47,7 +48,149 @@ export interface ComboboxProps {
     option: ComboboxOption,
     state: { active: boolean; selected: boolean; group?: ComboboxGroup; index: number },
   ) => ReactNode;
+  children?: ReactNode;
 }
+
+export interface ComboboxInputProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, "value" | "onChange"> {
+  value?: string;
+  onValueChange?: (value: string) => void;
+}
+
+export interface ComboboxItemProps {
+  id?: string;
+  value: string;
+  keywords?: string[];
+  disabled?: boolean;
+  onSelect?: () => void;
+  children: ReactNode | ((state: { active: boolean; selected: boolean }) => ReactNode);
+}
+
+export interface ComboboxGroupProps {
+  id?: string;
+  heading?: ReactNode;
+  children: ReactNode;
+}
+
+interface RegisteredOption {
+  id: string;
+  value: string;
+  keywords: string[];
+  disabled: boolean;
+  onSelect?: () => void;
+  group?: ComboboxGroup;
+}
+
+interface CompoundComboboxContext {
+  listboxId: string;
+  query: string;
+  selectedValue: string;
+  activeId: string | null;
+  options: RegisteredOption[];
+  shouldFilter: boolean;
+  setQuery: (value: string) => void;
+  registerOption: (option: RegisteredOption) => () => void;
+  setActiveId: (id: string) => void;
+  selectOption: (option: RegisteredOption) => void;
+  isVisible: (option: RegisteredOption) => boolean;
+  openList: () => void;
+  closeList: () => void;
+  setInputElement: (element: HTMLInputElement | null) => void;
+  setListboxElement: (element: HTMLDivElement | null) => void;
+}
+
+const CompoundComboboxContext = createContext<CompoundComboboxContext | null>(null);
+const CompoundComboboxGroupContext = createContext<ComboboxGroup | undefined>(undefined);
+const noKeywords: string[] = [];
+
+function useCompoundCombobox() {
+  const context = useContext(CompoundComboboxContext);
+  if (!context) throw new Error("Combobox compound components must be used inside Combobox");
+  return context;
+}
+
+function compoundMatches(option: RegisteredOption, query: string) {
+  const normalized = query.trim().toLowerCase();
+  return !normalized || [option.value, ...option.keywords].some((text) => text.toLowerCase().includes(normalized));
+}
+
+function CompoundComboboxInput({ value, onValueChange, ...props }: ComboboxInputProps) {
+  const context = useCompoundCombobox();
+  const selectable = context.options.filter((option) => !option.disabled && context.isVisible(option));
+  const activeIndex = selectable.findIndex((option) => option.id === context.activeId);
+  useEffect(() => {
+    if (value !== undefined) context.setQuery(value);
+  }, [context, value]);
+  return (
+    <input
+      {...props}
+      ref={context.setInputElement}
+      type={props.type ?? "text"}
+      role="combobox"
+      aria-expanded="true"
+      aria-controls={context.listboxId}
+      aria-autocomplete="list"
+      aria-activedescendant={context.activeId ?? undefined}
+      value={value ?? context.query}
+      autoComplete="off"
+      onFocus={context.openList}
+      onChange={(event) => { context.setQuery(event.target.value); onValueChange?.(event.target.value); context.openList(); }}
+      onKeyDown={(event) => {
+        props.onKeyDown?.(event);
+        if (event.defaultPrevented) return;
+        if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+          event.preventDefault();
+          const nextIndex = event.key === "ArrowDown"
+            ? Math.min(activeIndex + 1, selectable.length - 1)
+            : Math.max(activeIndex - 1, 0);
+          context.setActiveId(selectable[nextIndex]?.id ?? "");
+        } else if (event.key === "Enter") {
+          const active = selectable[activeIndex];
+          if (active) { event.preventDefault(); context.selectOption(active); }
+        } else if (event.key === "Escape") context.closeList();
+      }}
+      className={[styles.input, props.className].filter(Boolean).join(" ")}
+    />
+  );
+}
+
+function CompoundComboboxItem({ id, value, keywords, disabled = false, onSelect, children }: ComboboxItemProps) {
+  const context = useCompoundCombobox();
+  const group = useContext(CompoundComboboxGroupContext);
+  const generated = useId();
+  const optionId = id ?? `${context.listboxId}-option-${generated.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+  const normalizedKeywords = keywords ?? noKeywords;
+  const option = useMemo(() => ({ id: optionId, value, keywords: normalizedKeywords, disabled, onSelect, group }), [disabled, group, normalizedKeywords, onSelect, optionId, value]);
+  useEffect(() => context.registerOption(option), [context.registerOption, option]);
+  if (!context.isVisible(option)) return null;
+  const active = context.activeId === optionId;
+  const selected = context.selectedValue === value;
+  return (
+    <div id={optionId} role="option" aria-selected={selected} aria-disabled={disabled || undefined} data-active={dataAttr(active)} className={styles.option}
+      onPointerDown={(event) => event.preventDefault()}
+      onPointerMove={() => { if (!disabled) context.setActiveId(optionId); }}
+      onClick={() => { if (!disabled) context.selectOption(option); }}>
+      {typeof children === "function" ? children({ active, selected }) : children}
+    </div>
+  );
+}
+
+function CompoundComboboxGroup({ id, heading, children }: ComboboxGroupProps) {
+  const context = useCompoundCombobox();
+  const generated = useId();
+  const groupId = id ?? `${context.listboxId}-group-${generated.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+  const headingId = `${groupId}-heading`;
+  const group = useMemo(() => ({ id: groupId, label: typeof heading === "string" ? heading : undefined, items: [] }), [groupId, heading]);
+  return <CompoundComboboxGroupContext.Provider value={group}><div role="group" aria-labelledby={heading !== undefined ? headingId : undefined}>{heading !== undefined ? <div id={headingId} role="presentation" className={styles.groupLabel}>{heading}</div> : null}{children}</div></CompoundComboboxGroupContext.Provider>;
+}
+
+function CompoundComboboxList({ children }: { children: ReactNode }) {
+  const context = useCompoundCombobox();
+  return <div ref={context.setListboxElement} id={context.listboxId} role="listbox" popover="manual" data-slot="combobox-listbox" className={styles.listbox}>{children}</div>;
+}
+
+function CompoundComboboxEmpty({ children }: { children: ReactNode }) { return <div className={styles.empty}>{children}</div>; }
+function CompoundComboboxLoading({ children }: { children: ReactNode }) { return <div role="status" className={styles.empty}>{children}</div>; }
 
 /**
  * The WAI-ARIA 1.2 combobox pattern: a real `<input role="combobox">`
@@ -70,10 +213,12 @@ export function Combobox({
   onValueChange,
   placeholder,
   emptyMessage = "No results",
+  shouldFilter = true,
   placement = "bottom",
   align = "center",
   offset = 8,
   renderOption,
+  children,
 }: ComboboxProps) {
   const [selectedValue, setSelectedValue] = useControllableState({
     value,
@@ -89,6 +234,9 @@ export function Combobox({
   const [inputText, setInputText] = useState(selectedOption?.label ?? "");
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
+  const [compoundQuery, setCompoundQuery] = useState("");
+  const [compoundOptions, setCompoundOptions] = useState<RegisteredOption[]>([]);
+  const [compoundActiveId, setCompoundActiveId] = useState<string | null>(null);
 
   const inputRef = useRef<HTMLInputElement>(null);
   const listboxRef = useRef<HTMLDivElement>(null);
@@ -103,7 +251,7 @@ export function Combobox({
     const filteredGroups = sourceGroups
       .map((group) => ({
         ...group,
-        items: group.items.filter((option) => option.label.toLowerCase().includes(inputText.toLowerCase())),
+        items: group.items.filter((option) => !shouldFilter || option.label.toLowerCase().includes(inputText.toLowerCase())),
       }))
       .filter((group) => group.items.length > 0);
 
@@ -115,7 +263,7 @@ export function Combobox({
     }
 
     return { filteredGroups, entries, isGrouped };
-  }, [groups, inputText, options]);
+  }, [groups, inputText, options, shouldFilter]);
 
   const { anchorRef, floatingRef } = useFloatingPosition<HTMLInputElement, HTMLDivElement>({
     open,
@@ -125,6 +273,28 @@ export function Combobox({
   });
 
   const { closing, playExit, cancelExit } = usePopoverExit(listboxRef);
+
+  const registerOption = useCallback((option: RegisteredOption) => {
+    setCompoundOptions((current) => [...current.filter((entry) => entry.id !== option.id), option]);
+    return () => setCompoundOptions((current) => current.filter((entry) => entry.id !== option.id));
+  }, []);
+  const compoundVisible = useCallback(
+    (option: RegisteredOption) => !shouldFilter || compoundMatches(option, compoundQuery),
+    [compoundQuery, shouldFilter],
+  );
+  const compoundSelectable = useMemo(
+    () => compoundOptions.filter((option) => !option.disabled && compoundVisible(option)),
+    [compoundOptions, compoundVisible],
+  );
+  const compoundSetActiveId = useCallback((nextId: string) => setCompoundActiveId(nextId || null), []);
+  const setInputElement = useCallback((element: HTMLInputElement | null) => {
+    inputRef.current = element;
+    anchorRef.current = element;
+  }, [anchorRef]);
+  const setListboxElement = useCallback((element: HTMLDivElement | null) => {
+    listboxRef.current = element;
+    floatingRef.current = element;
+  }, [floatingRef]);
 
   function openList() {
     cancelExit();
@@ -149,6 +319,13 @@ export function Combobox({
     setInputText(option.label);
     closeList();
   }
+
+  const selectCompoundOption = useCallback((option: RegisteredOption) => {
+    setSelectedValue(option.value);
+    setCompoundQuery(option.value);
+    option.onSelect?.();
+    closeList();
+  }, [closeList, setSelectedValue]);
 
   useEffect(() => {
     if (!open) return;
@@ -177,8 +354,32 @@ export function Combobox({
     if (activeIndex < 0) return;
     listboxRef.current
       ?.querySelector(`[id="${listboxId}-option-${activeIndex}"]`)
-      ?.scrollIntoView({ block: "nearest" });
+      ?.scrollIntoView?.({ block: "nearest" });
   }, [activeIndex, listboxId]);
+
+  useEffect(() => {
+    setCompoundActiveId((current) => compoundSelectable.some((option) => option.id === current)
+      ? current
+      : compoundSelectable[0]?.id ?? null);
+  }, [compoundSelectable]);
+
+  const compoundContext = useMemo<CompoundComboboxContext>(() => ({
+    listboxId,
+    query: compoundQuery,
+    selectedValue,
+    activeId: compoundActiveId,
+    options: compoundOptions,
+    shouldFilter,
+    setQuery: setCompoundQuery,
+    registerOption,
+    setActiveId: compoundSetActiveId,
+    selectOption: selectCompoundOption,
+    isVisible: compoundVisible,
+    openList,
+    closeList,
+    setInputElement,
+    setListboxElement,
+  }), [closeList, compoundActiveId, compoundOptions, compoundQuery, compoundSetActiveId, compoundVisible, listboxId, openList, registerOption, selectCompoundOption, selectedValue, setInputElement, setListboxElement, shouldFilter]);
 
   function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
     const maxIndex = filtered.entries.length - 1;
@@ -217,6 +418,7 @@ export function Combobox({
   const activeEntry = filtered.entries[activeIndex];
 
   return (
+    <CompoundComboboxContext.Provider value={compoundContext}>
     <div
       className={styles.root}
       ref={rootRef}
@@ -230,7 +432,7 @@ export function Combobox({
       >
         {label}
       </label>
-      <input
+      {children ? children : <input
         ref={mergeRefs(inputRef, anchorRef)}
         id={id}
         role="combobox"
@@ -249,8 +451,8 @@ export function Combobox({
         }}
         onKeyDown={handleKeyDown}
         className={styles.input}
-      />
-      <div
+      />}
+      {children ? null : <div
         ref={mergeRefs(listboxRef, floatingRef)}
         id={listboxId}
         role="listbox"
@@ -317,7 +519,17 @@ export function Combobox({
             return nodes;
           })()
         )}
-      </div>
+      </div>}
     </div>
+    </CompoundComboboxContext.Provider>
   );
+}
+
+export namespace Combobox {
+  export const Input = CompoundComboboxInput;
+  export const List = CompoundComboboxList;
+  export const Group = CompoundComboboxGroup;
+  export const Item = CompoundComboboxItem;
+  export const Empty = CompoundComboboxEmpty;
+  export const Loading = CompoundComboboxLoading;
 }

--- a/packages/react/src/components/CommandPalette/CommandPalette.module.css
+++ b/packages/react/src/components/CommandPalette/CommandPalette.module.css
@@ -28,6 +28,8 @@
   /* Command Palette reads as a compact action surface, not a full dialog
     sheet, so it uses the container tier's radius/padding pair to keep
     Round mode from over-inflating edge padding. */
+  /* The fully rounded palette stays compact: 16px on every edge. */
+  --kernel-padding-container-curve: var(--kernel-space-4);
   padding: var(--kernel-padding-container-curve);
   background-color: var(--kernel-color-surface-raised);
   color: var(--kernel-color-text);
@@ -116,8 +118,7 @@
   flex-shrink: 0;
   inline-size: 100%;
   block-size: calc(var(--kernel-space-unit) * 12);
-  border: none;
-  border-block-end: var(--kernel-border-width) solid var(--kernel-color-border);
+  border: var(--kernel-border-width) solid var(--kernel-color-border);
   border-radius: var(--kernel-radius-control);
   background-color: transparent;
   color: var(--kernel-color-text);
@@ -132,7 +133,6 @@
 }
 
 .listbox {
-  overflow-y: auto;
   overscroll-behavior: contain;
   scroll-padding-block: var(--kernel-space-1);
   max-block-size: 20rem;

--- a/packages/react/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/react/src/components/CommandPalette/CommandPalette.test.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { CommandPalette } from "./CommandPalette";
+
+describe("CommandPalette", () => {
+  it("keeps the legacy items API filtering and selection behavior", async () => {
+    const onSelect = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <CommandPalette
+        open
+        onOpenChange={onOpenChange}
+        items={[
+          { id: "new-file", label: "New file", onSelect },
+          { id: "save", label: "Save", description: "Save the document", onSelect },
+        ]}
+      />,
+    );
+
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "document" } });
+    expect(screen.getByRole("option")).toHaveAttribute("id", "save");
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("supports controlled query state and compound rich options", async () => {
+    function Example() {
+      const [query, setQuery] = useState("");
+      return (
+        <CommandPalette open onOpenChange={() => {}} shouldFilter={false}>
+          <CommandPalette.Input value={query} onValueChange={setQuery} aria-label="Search lessons" />
+          <CommandPalette.List>
+            <CommandPalette.Group heading="Engineering Track">
+              <CommandPalette.Item id="lesson-flexbox" value="flexbox" onSelect={() => {}}>
+                {({ active }) => <span data-testid="lesson-state">{active ? "active lesson" : "lesson"}</span>}
+              </CommandPalette.Item>
+              <CommandPalette.Item id="disabled-section" value="section" disabled onSelect={() => {}}>
+                Disabled section
+              </CommandPalette.Item>
+              <CommandPalette.Item id="section-flexbox-layout" value="layout" onSelect={() => {}}>
+                Section result
+              </CommandPalette.Item>
+            </CommandPalette.Group>
+            <CommandPalette.Loading>Searching...</CommandPalette.Loading>
+          </CommandPalette.List>
+        </CommandPalette>
+      );
+    }
+
+    render(<Example />);
+    const input = screen.getByRole("combobox", { name: "Search lessons" });
+    await waitFor(() => expect(input).toHaveAttribute("aria-activedescendant", "lesson-flexbox"));
+    expect(screen.getByTestId("lesson-state")).toHaveTextContent("active lesson");
+    expect(screen.getByRole("status")).toHaveTextContent("Searching...");
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(input).toHaveAttribute("aria-activedescendant", "section-flexbox-layout");
+    expect(screen.getByTestId("lesson-state")).toHaveTextContent("lesson");
+  });
+
+  it("preserves the active stable ID when compound results are replaced", async () => {
+    function Example() {
+      const [results, setResults] = useState(["one", "two"]);
+      return (
+        <>
+          <button type="button" onClick={() => setResults(["two", "three"])}>Replace</button>
+          <CommandPalette open onOpenChange={() => {}}>
+            <CommandPalette.Input aria-label="Search" />
+            <CommandPalette.List>
+              {results.map((result) => (
+                <CommandPalette.Item key={result} id={result} value={result} onSelect={() => {}}>
+                  {result}
+                </CommandPalette.Item>
+              ))}
+            </CommandPalette.List>
+          </CommandPalette>
+        </>
+      );
+    }
+
+    render(<Example />);
+    const input = screen.getByRole("combobox", { name: "Search" });
+    await waitFor(() => expect(input).toHaveAttribute("aria-activedescendant", "one"));
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(input).toHaveAttribute("aria-activedescendant", "two");
+    fireEvent.click(screen.getByRole("button", { name: "Replace" }));
+    await waitFor(() => expect(input).toHaveAttribute("aria-activedescendant", "two"));
+    expect(document.getElementById("two")).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/react/src/components/CommandPalette/CommandPalette.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useId, useMemo, useRef, useState } from "react";
-import type { KeyboardEvent, ReactNode } from "react";
-import { dataAttr, mergeRefs } from "../../utils/polymorphic";
+import { createContext, useCallback, useContext, useEffect, useId, useMemo, useRef, useState } from "react";
+import type { InputHTMLAttributes, KeyboardEvent, ReactNode } from "react";
+import { dataAttr } from "../../utils/polymorphic";
 import { prefersReducedMotion, waitForExitTransition } from "../../utils/exitTransition";
+import { ScrollArea } from "../ScrollArea/ScrollArea";
 import styles from "./CommandPalette.module.css";
 
 export interface CommandPaletteItem {
@@ -26,37 +27,208 @@ export interface CommandPaletteProps {
   emptyMessage?: ReactNode;
   /** Light frost on the `::backdrop` (`backdrop-filter: blur(8px)`). */
   blur?: boolean;
+  /** Set to false when results are filtered by the consumer. */
+  shouldFilter?: boolean;
   renderItem?: (
     item: CommandPaletteItem,
     state: { active: boolean; group?: CommandPaletteGroup; index: number },
   ) => ReactNode;
+  children?: ReactNode;
 }
 
-function matchesQuery(item: CommandPaletteItem, query: string) {
-  const q = query.toLowerCase();
+export interface CommandPaletteInputProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, "value" | "onChange"> {
+  value?: string;
+  onValueChange?: (value: string) => void;
+}
+
+export interface CommandPaletteItemProps {
+  id?: string;
+  value?: string;
+  keywords?: string[];
+  disabled?: boolean;
+  onSelect?: () => void;
+  children: ReactNode | ((state: { active: boolean }) => ReactNode);
+}
+
+export interface CommandPaletteGroupProps {
+  id?: string;
+  heading?: ReactNode;
+  children: ReactNode;
+}
+
+interface RegisteredItem {
+  id: string;
+  value: string;
+  keywords: string[];
+  disabled: boolean;
+  onSelect?: () => void;
+  group?: CommandPaletteGroup;
+}
+
+interface PaletteContextValue {
+  listboxId: string;
+  query: string;
+  activeId: string | null;
+  registerItem: (item: RegisteredItem) => () => void;
+  setQuery: (value: string) => void;
+  setActiveId: (id: string, fromKeyboard?: boolean) => void;
+  selectableItems: RegisteredItem[];
+  selectItem: (item: RegisteredItem) => void;
+  isVisible: (item: RegisteredItem) => boolean;
+  setInputElement: (element: HTMLInputElement | null) => void;
+}
+
+const PaletteContext = createContext<PaletteContextValue | null>(null);
+const GroupContext = createContext<CommandPaletteGroup | undefined>(undefined);
+const noKeywords: string[] = [];
+
+function usePaletteContext() {
+  const context = useContext(PaletteContext);
+  if (!context) throw new Error("CommandPalette compound components must be used inside CommandPalette");
+  return context;
+}
+
+function matchesQuery(item: RegisteredItem, query: string) {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return true;
+  return [item.value, ...item.keywords].some((value) => value.toLowerCase().includes(normalizedQuery));
+}
+
+function generatedId(id: string) {
+  return id.replace(/[^a-zA-Z0-9_-]/g, "-");
+}
+
+function CommandPaletteInput({ value, onValueChange, ...props }: CommandPaletteInputProps) {
+  const context = usePaletteContext();
+  const { query, setQuery } = context;
+
+  useEffect(() => {
+    if (value !== undefined) setQuery(value);
+  }, [setQuery, value]);
+
+  function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    props.onKeyDown?.(event);
+    if (event.defaultPrevented) return;
+    const activeIndex = context.selectableItems.findIndex((item) => item.id === context.activeId);
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      context.setActiveId(context.selectableItems[Math.min(activeIndex + 1, context.selectableItems.length - 1)]?.id ?? "");
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      context.setActiveId(context.selectableItems[Math.max(activeIndex - 1, 0)]?.id ?? "");
+    } else if (event.key === "Enter") {
+      const active = context.selectableItems[activeIndex];
+      if (active) {
+        event.preventDefault();
+        context.selectItem(active);
+      }
+    }
+  }
+
   return (
-    item.label.toLowerCase().includes(q) ||
-    (item.description?.toLowerCase().includes(q) ?? false)
+    <input
+      {...props}
+      ref={context.setInputElement}
+      type={props.type ?? "text"}
+      role="combobox"
+      aria-expanded="true"
+      aria-controls={context.listboxId}
+      aria-autocomplete="list"
+      aria-activedescendant={context.activeId ?? undefined}
+      value={value ?? query}
+      autoComplete="off"
+      onChange={(event) => {
+        setQuery(event.target.value);
+        onValueChange?.(event.target.value);
+      }}
+      onKeyDown={handleKeyDown}
+      className={[styles.input, props.className].filter(Boolean).join(" ")}
+    />
   );
 }
 
-/**
- * A real `<dialog>`, opened with `showModal()`, the same reasoning as
- * `Dialog`: native top-layer stacking, a native focus trap, and native
- * Escape-to-close, none of it reimplemented in JavaScript. The filter
- * input inside follows the WAI-ARIA combobox pattern `Combobox` already
- * uses: a `role="listbox"` of `role="option"` items, an
- * `aria-activedescendant` pointing at whichever one is highlighted, and
- * focus staying on the input the whole time rather than moving into the
- * list, so a screen reader announces the active option without ever
- * leaving the text field.
- *
- * Enter/exit motion (opacity + slight scale + settle) is the default —
- * Escape and backdrop dismiss are held via `cancel`/`data-state="closing"`
- * until the exit transition finishes, matching `Dialog`, so the close
- * doesn't snap shut underneath the animation.
- */
-export function CommandPalette({
+function CommandPaletteItem({ id, value, keywords, disabled = false, onSelect, children }: CommandPaletteItemProps) {
+  const context = usePaletteContext();
+  const group = useContext(GroupContext);
+  const generated = useId();
+  const itemId = id ?? `${context.listboxId}-item-${generatedId(generated)}`;
+  const normalizedKeywords = keywords ?? noKeywords;
+  const entry = useMemo<RegisteredItem>(
+    () => ({ id: itemId, value: value ?? "", keywords: normalizedKeywords, disabled, onSelect, group }),
+    [disabled, group, itemId, normalizedKeywords, onSelect, value],
+  );
+
+  useEffect(() => context.registerItem(entry), [context.registerItem, entry]);
+  if (!context.isVisible(entry)) return null;
+
+  const active = context.activeId === itemId;
+  return (
+    <div
+      id={itemId}
+      role="option"
+      aria-selected={active}
+      aria-disabled={disabled || undefined}
+      data-active={dataAttr(active)}
+      className={styles.option}
+      onPointerDown={(event) => event.preventDefault()}
+      onPointerMove={() => { if (!disabled) context.setActiveId(itemId, false); }}
+      onClick={() => { if (!disabled) context.selectItem(entry); }}
+    >
+      {typeof children === "function" ? children({ active }) : children}
+    </div>
+  );
+}
+
+function CommandPaletteGroup({ id, heading, children }: CommandPaletteGroupProps) {
+  const context = usePaletteContext();
+  const generated = useId();
+  const groupId = id ?? `${context.listboxId}-group-${generatedId(generated)}`;
+  const headingId = `${groupId}-heading`;
+  const group = useMemo<CommandPaletteGroup>(
+    () => ({ id: groupId, label: typeof heading === "string" ? heading : undefined, items: [] }),
+    [groupId, heading],
+  );
+
+  return (
+    <GroupContext.Provider value={group}>
+      <div role="group" aria-labelledby={heading !== undefined ? headingId : undefined}>
+        {heading !== undefined ? <div id={headingId} role="presentation" className={styles.groupLabel}>{heading}</div> : null}
+        {children}
+      </div>
+    </GroupContext.Provider>
+  );
+}
+
+function CommandPaletteList({ children }: { children: ReactNode }) {
+  const context = usePaletteContext();
+  return <ScrollArea id={context.listboxId} role="listbox" edgeShadow className={styles.listbox}>{children}</ScrollArea>;
+}
+
+function CommandPaletteEmpty({ children }: { children: ReactNode }) {
+  return <div className={styles.empty}>{children}</div>;
+}
+
+function CommandPaletteLoading({ children }: { children: ReactNode }) {
+  return <div role="status" className={styles.empty}>{children}</div>;
+}
+
+function CommandPaletteShorthand({ items, groups, renderItem }: Pick<CommandPaletteProps, "items" | "groups" | "renderItem">) {
+  const isGrouped = Boolean(groups && groups.length > 0);
+  const sourceGroups = isGrouped ? groups ?? [] : [{ id: "__items__", items: items ?? [] }];
+  return <>
+    {sourceGroups.map((group) => <CommandPaletteGroup key={group.id} id={group.id} heading={group.label}>
+      {group.items.map((item, index) => <CommandPaletteItem key={item.id} id={item.id} value={`${item.label} ${item.description ?? ""}`} onSelect={item.onSelect}>
+        {({ active }) => renderItem
+          ? renderItem(item, { active, group: isGrouped ? group : undefined, index })
+          : <><div className={styles.optionLabel}>{item.label}</div>{item.description ? <div className={styles.optionDescription}>{item.description}</div> : null}</>}
+      </CommandPaletteItem>)}
+    </CommandPaletteGroup>)}
+  </>;
+}
+
+function CommandPaletteRoot({
   open,
   onOpenChange,
   items = [],
@@ -64,71 +236,87 @@ export function CommandPalette({
   placeholder = "Filter commands",
   emptyMessage = "No results",
   blur = false,
+  shouldFilter = true,
   renderItem,
+  children,
 }: CommandPaletteProps) {
   const [query, setQuery] = useState("");
-  const [activeIndex, setActiveIndex] = useState(0);
+  const [registeredItems, setRegisteredItems] = useState<RegisteredItem[]>([]);
+  const [activeId, setActiveIdState] = useState<string | null>(null);
   const [closing, setClosing] = useState(false);
-
   const dialogRef = useRef<HTMLDialogElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputElementRef = useRef<HTMLInputElement | null>(null);
   const exitAbortRef = useRef<AbortController | null>(null);
   const skipCloseSyncRef = useRef(false);
   const keyboardNavRef = useRef(false);
   const id = useId();
   const listboxId = `${id}-listbox`;
 
-  const filtered = useMemo(() => {
-    const isGrouped = Boolean(groups && groups.length > 0);
-    const sourceGroups = isGrouped ? (groups as CommandPaletteGroup[]) : [{ id: "__items__", items }];
-    const filteredGroups = sourceGroups
-      .map((group) => ({ ...group, items: group.items.filter((item) => matchesQuery(item, query)) }))
-      .filter((group) => group.items.length > 0);
+  const registerItem = useCallback((item: RegisteredItem) => {
+    setRegisteredItems((current) => [...current.filter((entry) => entry.id !== item.id), item]);
+    return () => setRegisteredItems((current) => current.filter((entry) => entry.id !== item.id));
+  }, []);
+  const isVisible = useCallback((item: RegisteredItem) => !shouldFilter || matchesQuery(item, query), [query, shouldFilter]);
+  const selectableItems = useMemo(
+    () => registeredItems.filter((item) => !item.disabled && isVisible(item)),
+    [isVisible, registeredItems],
+  );
+  const setActiveId = useCallback((nextId: string, fromKeyboard = true) => {
+    keyboardNavRef.current = fromKeyboard;
+    setActiveIdState(nextId || null);
+  }, []);
+  const setInputElement = useCallback((element: HTMLInputElement | null) => {
+    inputElementRef.current = element;
+  }, []);
 
-    const entries: Array<{ item: CommandPaletteItem; group?: CommandPaletteGroup; flatIndex: number }> = [];
-    for (const group of filteredGroups) {
-      for (const item of group.items) {
-        entries.push({ item, group: isGrouped ? group : undefined, flatIndex: entries.length });
-      }
-    }
+  useEffect(() => {
+    setActiveIdState((current) => selectableItems.some((item) => item.id === current) ? current : selectableItems[0]?.id ?? null);
+  }, [selectableItems]);
 
-    return { filteredGroups, entries, isGrouped };
-  }, [groups, items, query]);
+  useEffect(() => {
+    if (!keyboardNavRef.current || !activeId) return;
+    keyboardNavRef.current = false;
+    document.getElementById(activeId)?.scrollIntoView?.({ block: "nearest" });
+  }, [activeId]);
+
+  const context = useMemo<PaletteContextValue>(() => ({
+    listboxId,
+    query,
+    activeId,
+    registerItem,
+    setQuery,
+    setActiveId,
+    selectableItems,
+    selectItem: (item) => {
+      item.onSelect?.();
+      onOpenChange(false);
+    },
+    isVisible,
+    setInputElement,
+  }), [activeId, isVisible, listboxId, onOpenChange, query, registerItem, selectableItems, setActiveId, setInputElement]);
 
   useEffect(() => {
     const node = dialogRef.current;
     if (!node) return;
-
     if (open) {
       exitAbortRef.current?.abort();
-      exitAbortRef.current = null;
       setClosing(false);
       if (!node.open) node.showModal();
       return;
     }
-
     if (!node.open) return;
-
-    let cancelled = false;
     const controller = new AbortController();
     exitAbortRef.current?.abort();
     exitAbortRef.current = controller;
     setClosing(true);
-
     void (async () => {
-      if (!prefersReducedMotion()) {
-        await waitForExitTransition(node, { signal: controller.signal });
-      }
-      if (cancelled || controller.signal.aborted) return;
+      if (!prefersReducedMotion()) await waitForExitTransition(node, { signal: controller.signal });
+      if (controller.signal.aborted) return;
       skipCloseSyncRef.current = true;
       node.close();
       setClosing(false);
     })();
-
-    return () => {
-      cancelled = true;
-      controller.abort();
-    };
+    return () => controller.abort();
   }, [open]);
 
   useEffect(() => {
@@ -146,174 +334,40 @@ export function CommandPalette({
   }, [onOpenChange]);
 
   useEffect(() => {
-    return () => exitAbortRef.current?.abort();
-  }, []);
-
-  useEffect(() => {
     if (!open) return;
     setQuery("");
-    setActiveIndex(0);
-    requestAnimationFrame(() => inputRef.current?.focus());
+    setActiveIdState(null);
+    requestAnimationFrame(() => inputElementRef.current?.focus());
   }, [open]);
 
-  useEffect(() => {
-    if (filtered.entries.length === 0) {
-      setActiveIndex(0);
-      return;
-    }
-    setActiveIndex((index) => Math.min(index, filtered.entries.length - 1));
-  }, [filtered.entries.length]);
-
-  /** Only keyboard nav auto-scrolls the active item into view — hover
-   * (`onPointerMove` below) sets `activeIndex` too, and scrolling out from
-   * under a stationary pointer would fight the user rather than help. */
-  useEffect(() => {
-    if (!keyboardNavRef.current) return;
-    keyboardNavRef.current = false;
-    dialogRef.current
-      ?.querySelector(`[id="${listboxId}-option-${activeIndex}"]`)
-      ?.scrollIntoView({ block: "nearest" });
-  }, [activeIndex, listboxId]);
-
-  function requestClose() {
-    if (!open || closing) return;
-    onOpenChange(false);
-  }
-
-  function selectItem(item: CommandPaletteItem) {
-    item.onSelect();
-    requestClose();
-  }
-
-  function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
-    const maxIndex = filtered.entries.length - 1;
-
-    switch (event.key) {
-      case "ArrowDown":
-        event.preventDefault();
-        if (maxIndex < 0) break;
-        keyboardNavRef.current = true;
-        setActiveIndex((index) => Math.min(index + 1, maxIndex));
-        break;
-      case "ArrowUp":
-        event.preventDefault();
-        if (maxIndex < 0) break;
-        keyboardNavRef.current = true;
-        setActiveIndex((index) => Math.max(index - 1, 0));
-        break;
-      case "Enter": {
-        const active = filtered.entries[activeIndex]?.item;
-        if (active) {
-          event.preventDefault();
-          selectItem(active);
-        }
-        break;
-      }
-    }
-  }
-
-  const activeEntry = filtered.entries[activeIndex];
   const dataState = closing ? "closing" : open || dialogRef.current?.open ? "open" : undefined;
+  const shorthand = <><CommandPaletteInput placeholder={placeholder} aria-label={placeholder} />
+    <CommandPaletteList>{selectableItems.length === 0 ? <CommandPaletteEmpty>{emptyMessage}</CommandPaletteEmpty> : null}
+      <CommandPaletteShorthand items={items} groups={groups} renderItem={renderItem} />
+    </CommandPaletteList></>;
 
-  return (
-    <dialog
-      ref={dialogRef}
-      className={styles.content}
-      aria-label="Command palette"
-      data-state={dataState}
-      data-open={dataAttr(open && !closing)}
-      data-closing={dataAttr(closing)}
-      data-blur={dataAttr(blur)}
-      onClick={(event) => {
-        if (event.target === dialogRef.current) requestClose();
-      }}
-      onCancel={(event) => {
-        event.preventDefault();
-        event.stopPropagation();
-        requestClose();
-      }}
-    >
-      <input
-        ref={mergeRefs(inputRef)}
-        type="text"
-        role="combobox"
-        aria-label={placeholder}
-        aria-expanded="true"
-        aria-controls={listboxId}
-        aria-autocomplete="list"
-        aria-activedescendant={activeEntry ? `${listboxId}-option-${activeEntry.flatIndex}` : undefined}
-        value={query}
-        placeholder={placeholder}
-        autoComplete="off"
-        onChange={(event) => {
-          setQuery(event.target.value);
-          setActiveIndex(0);
-        }}
-        onKeyDown={handleKeyDown}
-        className={styles.input}
-      />
-      <div id={listboxId} role="listbox" className={styles.listbox}>
-        {filtered.entries.length === 0 ? (
-          <div className={styles.empty}>{emptyMessage}</div>
-        ) : (
-          (() => {
-            const nodes: ReactNode[] = [];
-            let flatIndex = 0;
-
-            for (const group of filtered.filteredGroups) {
-              const headerId = group.label ? `${listboxId}-group-${group.id}` : undefined;
-
-              const itemNodes = group.items.map((item) => {
-                const currentIndex = flatIndex++;
-                const isActive = currentIndex === activeIndex;
-                return (
-                  <div
-                    key={`${group.id}-${item.id}`}
-                    id={`${listboxId}-option-${currentIndex}`}
-                    role="option"
-                    aria-selected={isActive}
-                    data-active={dataAttr(isActive)}
-                    className={styles.option}
-                    onPointerDown={(event) => event.preventDefault()}
-                    onPointerMove={() => setActiveIndex(currentIndex)}
-                    onClick={() => selectItem(item)}
-                  >
-                    {typeof renderItem === "function"
-                      ? renderItem(item, {
-                          active: isActive,
-                          group: filtered.isGrouped ? group : undefined,
-                          index: currentIndex,
-                        })
-                      : (
-                          <>
-                            <div className={styles.optionLabel}>{item.label}</div>
-                            {item.description ? (
-                              <div className={styles.optionDescription}>{item.description}</div>
-                            ) : null}
-                          </>
-                        )}
-                  </div>
-                );
-              });
-
-              if (headerId) {
-                nodes.push(
-                  <div key={`${group.id}-group`} role="group" aria-labelledby={headerId}>
-                    <div id={headerId} role="presentation" className={styles.groupLabel}>
-                      {group.label}
-                    </div>
-                    {itemNodes}
-                  </div>,
-                );
-              } else {
-                nodes.push(...itemNodes);
-              }
-            }
-
-            return nodes;
-          })()
-        )}
-      </div>
-    </dialog>
-  );
+  return <PaletteContext.Provider value={context}><dialog ref={dialogRef} className={styles.content} aria-label="Command palette"
+    data-state={dataState} data-open={dataAttr(open && !closing)} data-closing={dataAttr(closing)} data-blur={dataAttr(blur)}
+    onClick={(event) => { if (event.target === dialogRef.current) onOpenChange(false); }}
+    onCancel={(event) => { event.preventDefault(); event.stopPropagation(); onOpenChange(false); }}>
+    {children ?? shorthand}
+  </dialog></PaletteContext.Provider>;
 }
+
+type CommandPaletteComponent = typeof CommandPaletteRoot & {
+  Input: typeof CommandPaletteInput;
+  List: typeof CommandPaletteList;
+  Group: typeof CommandPaletteGroup;
+  Item: typeof CommandPaletteItem;
+  Empty: typeof CommandPaletteEmpty;
+  Loading: typeof CommandPaletteLoading;
+};
+
+export const CommandPalette = Object.assign(CommandPaletteRoot, {
+  Input: CommandPaletteInput,
+  List: CommandPaletteList,
+  Group: CommandPaletteGroup,
+  Item: CommandPaletteItem,
+  Empty: CommandPaletteEmpty,
+  Loading: CommandPaletteLoading,
+}) as CommandPaletteComponent;

--- a/packages/react/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/react/src/components/ScrollArea/ScrollArea.tsx
@@ -60,13 +60,15 @@ export const ScrollArea = forwardRef<HTMLDivElement, ScrollAreaProps>(
 
       measure();
       el.addEventListener("scroll", scheduleMeasure, { passive: true });
-      const resizeObserver = new ResizeObserver(scheduleMeasure);
-      resizeObserver.observe(el);
+      const resizeObserver = typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(scheduleMeasure);
+      resizeObserver?.observe(el);
 
       return () => {
         if (frame !== null) cancelAnimationFrame(frame);
         el.removeEventListener("scroll", scheduleMeasure);
-        resizeObserver.disconnect();
+        resizeObserver?.disconnect();
       };
     }, [edgeShadow]);
 

--- a/packages/react/src/components/Sheet/Sheet.tsx
+++ b/packages/react/src/components/Sheet/Sheet.tsx
@@ -17,6 +17,7 @@ import {
 } from "../../utils/sheetDrag";
 import { prefersReducedMotion } from "../../utils/exitTransition";
 import { runSpring, type SpringConfig } from "../../utils/spring";
+import { ScrollArea } from "../ScrollArea/ScrollArea";
 import { useSheetDrag } from "./useSheetDrag";
 import styles from "./Sheet.module.css";
 
@@ -264,9 +265,13 @@ export const Sheet = forwardRef<HTMLDialogElement, SheetProps>(function Sheet(
           among them would scroll away with the rest. Sheet splits that wrapper
           into a scrolling body and a pinned footer instead, which is also what
           lets the footer own the safe-area padding. */}
-      <div className={[styles.body, bodyClassName].filter(Boolean).join(" ")} data-slot="sheet-body">
+      <ScrollArea
+        edgeShadow
+        className={[styles.body, bodyClassName].filter(Boolean).join(" ")}
+        data-slot="sheet-body"
+      >
         {children}
-      </div>
+      </ScrollArea>
       {footer !== undefined ? (
         <div
           ref={setFooter}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -153,7 +153,14 @@ export type {
 } from "./components/DropdownMenu/DropdownMenu";
 
 export { Combobox } from "./components/Combobox/Combobox";
-export type { ComboboxProps, ComboboxOption, ComboboxGroup } from "./components/Combobox/Combobox";
+export type {
+  ComboboxProps,
+  ComboboxOption,
+  ComboboxGroup,
+  ComboboxInputProps,
+  ComboboxItemProps,
+  ComboboxGroupProps,
+} from "./components/Combobox/Combobox";
 
 export { ToastViewport, toast } from "./components/Toast/Toast";
 export type {
@@ -167,6 +174,9 @@ export type {
   CommandPaletteProps,
   CommandPaletteItem,
   CommandPaletteGroup,
+  CommandPaletteInputProps,
+  CommandPaletteItemProps,
+  CommandPaletteGroupProps,
 } from "./components/CommandPalette/CommandPalette";
 
 export {


### PR DESCRIPTION
## Summary
- add compound, controlled CommandPalette and Combobox APIs with grouped rich options
- preserve shorthand APIs while supporting external filtering, stable active IDs, disabled items, and loading/empty states
- improve ScrollArea composition, rounded palette spacing, grouped Combobox styling, checkbox text selection, and docs examples

## Verification
- `bun run --cwd packages/react typecheck`
- `bun run --cwd packages/elements typecheck`
- `bun run --cwd apps/docs typecheck`
- `bun run test:shape`
- React and Elements builds
- docs production build