### PR TITLE
Enforce Changesets for package PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,5 +8,5 @@
 - [ ] `bun run typecheck` passes
 - [ ] `bun run build` passes for changed packages
 - [ ] Docs page, demo, and playground added or updated when applicable
-- [ ] Changeset added if this should trigger a release
+- [ ] Changeset added for publishable package changes (`bunx changeset`), or this PR is docs-only/non-publishable
 - [ ] You can explain the change and stand behind it (LLM-assisted work is fine; untested spam is not)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -29,6 +31,14 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Require Changeset for package changes
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
+          GITHUB_PR_TITLE: ${{ github.event.pull_request.title }}
+        run: node scripts/check-changeset.mjs
 
       - name: Build packages
         run: bun run --filter '@kernelui-lib/*' build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,19 @@ This is a monorepo for a component library built on real semantic HTML.
 Read `README.md` for the project pitch. This file is operational
 guidance for anyone (human or agent) making changes here.
 
+## Release checklist for pull requests
+
+Any PR that changes a publishable package under `packages/react`,
+`packages/elements`, `packages/styles`, or `packages/cli` must include a
+`.changeset/<descriptive-name>.md` file describing the affected package(s) and
+the release level (`patch`, `minor`, or `major`). Run `bunx changeset` to create
+it. Docs-only changes do not need a Changeset. CI enforces this rule; the only
+exception is the Changesets-generated `Version Packages` release PR.
+
+When creating a PR, never leave the Changeset decision implicit: add the file
+or explicitly confirm that the PR is docs-only/non-publishable. A merged PR
+without a Changeset will not produce an npm or GitHub release.
+
 For **consuming** the published packages, don't read this file — read
 `packages/react/llms.txt` or `packages/elements/llms.txt` instead; they're
 the API reference. This file is about *building* the library, not using it.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:shape": "node scripts/check-shape-pairing.mjs",
     "test:motion:docs": "node scripts/disclosure-docs-check.mjs",
     "test:motion:filmstrip": "node scripts/disclosure-filmstrip.mjs",
+    "check:changeset": "node scripts/check-changeset.mjs",
     "registry:check": "bun run --cwd packages/registry check",
     "registry:build": "bun run --cwd packages/registry build",
     "changeset": "changeset",

--- a/scripts/check-changeset.mjs
+++ b/scripts/check-changeset.mjs
@@ -1,0 +1,30 @@
+import { execFileSync } from "node:child_process";
+
+const baseSha = process.env.GITHUB_BASE_SHA ?? process.argv[2];
+const headSha = process.env.GITHUB_SHA ?? process.argv[3] ?? "HEAD";
+const pullRequestTitle = process.env.GITHUB_PR_TITLE ?? "";
+
+if (!baseSha) {
+  console.error("[check-changeset] provide a base SHA or set GITHUB_BASE_SHA");
+  process.exit(1);
+}
+
+if (/^Version Packages(?:$|\s)/.test(pullRequestTitle)) {
+  console.log("[check-changeset] release PR exempt: Version Packages");
+  process.exit(0);
+}
+
+const changedFiles = execFileSync("git", ["diff", "--name-only", `${baseSha}...${headSha}`], { encoding: "utf8" })
+  .trim()
+  .split("\n")
+  .filter(Boolean);
+const publishableChange = changedFiles.some((file) => /^(packages\/(react|elements|styles|cli)\/)/.test(file));
+const changeset = changedFiles.some((file) => /^\.changeset\/[^/]+\.md$/.test(file));
+
+if (publishableChange && !changeset) {
+  console.error("[check-changeset] publishable package changes require a .changeset/*.md file");
+  console.error("[check-changeset] add one with `bunx changeset` and choose the affected package release type");
+  process.exit(1);
+}
+
+console.log(publishableChange ? "[check-changeset] ok: Changeset present" : "[check-changeset] ok: no publishable package changes");


### PR DESCRIPTION
## Summary
- require a `.changeset/*.md` file for PRs that change publishable packages
- document the release requirement for agents and contributors
- exempt the generated `Version Packages` release PR

## Verification
- missing Changeset path exits nonzero
- `Version Packages` exemption passes
- docs-only path passes
- `bun run test:shape`
- package and docs typechecks