### PR TITLE
Release composable search primitives

### DIFF
--- a/.changeset/composable-search-primitives.md
+++ b/.changeset/composable-search-primitives.md
@@ -1,0 +1,6 @@
+---
+"@kernelui-lib/react": minor
+"@kernelui-lib/elements": minor
+---
+
+Add composable CommandPalette and Combobox APIs with controlled queries, grouped rich options, external filtering, stable active IDs, disabled items, and loading/empty states. Improve scroll-area composition and grouped option styling across the paired packages.


### PR DESCRIPTION
## Summary
- add the missing Changeset for the already-merged composable CommandPalette and Combobox work
- bump `@kernelui-lib/react` and `@kernelui-lib/elements` as minor releases

Once merged, the release workflow will create the generated `Version Packages` PR. Merge that follow-up PR to publish npm packages and GitHub releases.

## Verification
- `bunx changeset status` reports minor bumps for React and Elements