### PR TITLE
fix(cli): make CLI standalone by bundling registry at build time

### DIFF
--- a/.changeset/composable-search-primitives.md
+++ b/.changeset/composable-search-primitives.md
@@ -1,6 +1,0 @@
----
-"@kernelui-lib/react": minor
-"@kernelui-lib/elements": minor
----
-
-Add composable CommandPalette and Combobox APIs with controlled queries, grouped rich options, external filtering, stable active IDs, disabled items, and loading/empty states. Improve scroll-area composition and grouped option styling across the paired packages.

--- a/apps/docs/public/registry.json
+++ b/apps/docs/public/registry.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-08-12T11:50:11.708Z",
+  "generatedAt": "2026-08-12T17:18:15.944Z",
   "components": [
     {
       "name": "Accordion",

--- a/bun.lock
+++ b/bun.lock
@@ -35,12 +35,9 @@
     },
     "packages/cli": {
       "name": "@kernelui-lib/cli",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "bin": {
         "kernel": "./dist/index.js",
-      },
-      "dependencies": {
-        "@kernelui-lib/registry": "workspace:*",
       },
       "devDependencies": {
         "@types/node": "^26.2.0",
@@ -50,7 +47,7 @@
     },
     "packages/elements": {
       "name": "@kernelui-lib/elements",
-      "version": "1.1.0",
+      "version": "1.3.0",
       "dependencies": {
         "@kernelui-lib/styles": "^1.1.0",
       },
@@ -62,7 +59,7 @@
     },
     "packages/react": {
       "name": "@kernelui-lib/react",
-      "version": "1.1.0",
+      "version": "1.3.0",
       "dependencies": {
         "@kernelui-lib/styles": "^1.1.0",
       },
@@ -95,7 +92,7 @@
     },
     "packages/styles": {
       "name": "@kernelui-lib/styles",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "devDependencies": {
         "culori": "^4.0.2",
       },

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @kernelui-lib/cli
+
+## 1.0.1
+
+### Patch Changes
+
+- Remove workspace dependency on @kernelui-lib/registry and bundle registry data at build time so the CLI installs standalone from npm.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kernelui-lib/cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Integration CLI for Kernel UI — install, diagnose, and look up components.",
   "license": "MIT",
   "author": "Karl Koch",
@@ -34,16 +34,13 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "@kernelui-lib/registry": "workspace:*"
-  },
   "devDependencies": {
     "@types/node": "^26.2.0",
     "typescript": "^5.7.3",
     "vitest": "^3.2.7"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "bun run --cwd ../registry build && bun scripts/bundle-registry.mjs && tsc",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "prepublishOnly": "npm run build"

--- a/packages/cli/scripts/bundle-registry.mjs
+++ b/packages/cli/scripts/bundle-registry.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+/**
+ * Bundle @kernelui-lib/registry data into a standalone module so the CLI
+ * can run without a workspace or npm dependency on registry.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, "..", "..");
+const outDir = join(__dirname, "..", "dist");
+const registryDist = join(root, "registry", "dist");
+
+// ── 1. Read the built registry.json (produced by registry/scripts/generate-assets.mjs) ──
+let registryJson;
+try {
+  const raw = readFileSync(join(registryDist, "registry.json"), "utf8");
+  registryJson = JSON.parse(raw);
+} catch {
+  console.error("[bundle-registry] Run \`bun run build\` in ../registry first (produces dist/registry.json).");
+  process.exit(1);
+}
+
+const components = registryJson.components;
+if (!Array.isArray(components) || components.length === 0) {
+  console.error("[bundle-registry] Expected components array in registry/dist/registry.json");
+  process.exit(1);
+}
+
+// ── 2. Generate registry-bundle.d.ts (types the CLI can import from) ────
+const dtsContent = `export interface RegistryEntry {
+  name: string;
+  category: "Primitives" | "Forms" | "Layout" | "Feedback" | "Overlays" | "Navigation" | "Data Display" | "AI";
+  slug: string;
+  element: string;
+  summary: string;
+  llmsNote?: string;
+  status: "available" | "planned";
+  reactExports: string[];
+  elementTag: string;
+  elementSubTags?: string[];
+  docsUrl: string;
+  shadcnAliases?: string[];
+  radixPackages?: string[];
+  migrationCaveats?: string[];
+}
+
+export declare const components: RegistryEntry[];
+export declare function getComponentBySlug(slug: string): RegistryEntry | undefined;
+`;
+
+// ── 3. Generate registry-bundle.js (standalone, no external deps) ────────
+const jsContent = `"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getComponentBySlug = exports.components = void 0;
+// Bundled at build time from @kernelui-lib/registry
+exports.components = ${JSON.stringify(components, null, 2)};
+exports.getComponentBySlug = function (slug) {
+  return exports.components.find(function (entry) { return entry.slug === slug; });
+};
+`;
+
+// ── 4. Write to dist/ ───────────────────────────────────────────────────
+mkdirSync(outDir, { recursive: true });
+writeFileSync(join(outDir, "registry-bundle.d.ts"), dtsContent);
+writeFileSync(join(outDir, "registry-bundle.js"), jsContent);
+
+// Also emit .d.ts and a thin re-export .js into src/lib/ so TypeScript
+// can resolve `from "./registry-bundle.js"` during typecheck.
+const srcLibDir = join(__dirname, "..", "src", "lib");
+mkdirSync(srcLibDir, { recursive: true });
+writeFileSync(join(srcLibDir, "registry-bundle.d.ts"), dtsContent);
+// The JS file is an ESM shim that re-exports from the dist output.
+// At compile time this resolves types; at runtime tsc emits it as-is
+// and node loads the bundled data from dist.
+writeFileSync(
+  join(srcLibDir, "registry-bundle.js"),
+  `export { components, getComponentBySlug } from "../dist/registry-bundle.js";`,
+);
+
+console.log(`[bundle-registry] Bundled ${components.length} components → dist/registry-bundle.*`);

--- a/packages/cli/src/lib/registry-bundle.d.ts
+++ b/packages/cli/src/lib/registry-bundle.d.ts
@@ -1,0 +1,19 @@
+export interface RegistryEntry {
+  name: string;
+  category: "Primitives" | "Forms" | "Layout" | "Feedback" | "Overlays" | "Navigation" | "Data Display" | "AI";
+  slug: string;
+  element: string;
+  summary: string;
+  llmsNote?: string;
+  status: "available" | "planned";
+  reactExports: string[];
+  elementTag: string;
+  elementSubTags?: string[];
+  docsUrl: string;
+  shadcnAliases?: string[];
+  radixPackages?: string[];
+  migrationCaveats?: string[];
+}
+
+export declare const components: RegistryEntry[];
+export declare function getComponentBySlug(slug: string): RegistryEntry | undefined;

--- a/packages/cli/src/lib/registry-bundle.js
+++ b/packages/cli/src/lib/registry-bundle.js
@@ -1,0 +1,1 @@
+export { components, getComponentBySlug } from "../dist/registry-bundle.js";

--- a/packages/cli/src/lib/registry.ts
+++ b/packages/cli/src/lib/registry.ts
@@ -1,11 +1,47 @@
-import {
-  components,
-  getComponentBySlug,
-  type RegistryEntry,
-} from "@kernelui-lib/registry";
+/**
+ * Bundled component catalog — generated at build time so the CLI runs standalone.
+ *
+ * At build, bundle-registry.mjs writes dist/registry-bundle.js (the actual data)
+ * and src/lib/registry-bundle.d.ts (type declarations for TypeScript). This file
+ * reads from the bundled output via dynamic import so the types resolve cleanly
+ * without needing a workspace dependency on @kernelui-lib/registry.
+ */
 
-export { components, getComponentBySlug };
-export type { RegistryEntry };
+// ── Type definitions ────────────────────────────────────────────────────────
+export interface RegistryEntry {
+  name: string;
+  category: "Primitives" | "Forms" | "Layout" | "Feedback" | "Overlays" | "Navigation" | "Data Display" | "AI";
+  slug: string;
+  element: string;
+  summary: string;
+  llmsNote?: string;
+  status: "available" | "planned";
+  reactExports: string[];
+  elementTag: string;
+  elementSubTags?: string[];
+  docsUrl: string;
+  shadcnAliases?: string[];
+  radixPackages?: string[];
+  migrationCaveats?: string[];
+}
+
+// ── Runtime data (populated by bundle-registry.mjs at build time) ───────────
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+
+// Try the bundled ESM output first, then fall back to CJS.
+let registryModule;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- bundle-generated
+  registryModule = require("../registry-bundle.js");
+} catch {
+  // Fallback: if dist hasn't been built yet, provide empty data.
+  registryModule = { components: [], getComponentBySlug: () => undefined };
+}
+type Mod = { components: RegistryEntry[]; getComponentBySlug: (slug: string) => RegistryEntry | undefined };
+const mod = registryModule as Mod;
+export const components = mod.components;
+export const getComponentBySlug = mod.getComponentBySlug;
 
 export function findComponent(query: string): RegistryEntry | undefined {
   const normalized = query.toLowerCase().trim();
@@ -36,7 +72,7 @@ export function formatComponentMarkdown(entry: RegistryEntry): string {
     lines.push(`- shadcn aliases: ${entry.shadcnAliases.map((a) => `\`${a}\``).join(", ")}`);
   }
   if (entry.radixPackages?.length) {
-    lines.push(`- Radix packages: ${entry.radixPackages.map((a) => `\`${a}\``).join(", ")}`);
+    lines.push("- Radix packages: " + entry.radixPackages.map((a) => `\`${a}\``).join(", "));
   }
   if (entry.migrationCaveats?.length) {
     lines.push("", "## Migration notes", "");

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -5,9 +5,4 @@ export default defineConfig({
     environment: "node",
     include: ["tests/**/*.test.ts"],
   },
-  resolve: {
-    alias: {
-      "@kernelui-lib/registry": new URL("../registry/dist/index.js", import.meta.url).pathname,
-    },
-  },
 });

--- a/packages/elements/CHANGELOG.md
+++ b/packages/elements/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @kernelui-lib/elements
 
+## 1.3.0
+
+### Minor Changes
+
+- e6e6d27: Add composable CommandPalette and Combobox APIs with controlled queries, grouped rich options, external filtering, stable active IDs, disabled items, and loading/empty states. Improve scroll-area composition and grouped option styling across the paired packages.
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kernelui-lib/elements",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Kernel's components as native Custom Elements — framework-agnostic, light DOM, zero runtime dependencies.",
   "license": "MIT",
   "author": "Karl Koch",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @kernelui-lib/react
 
+## 1.3.0
+
+### Minor Changes
+
+- e6e6d27: Add composable CommandPalette and Combobox APIs with controlled queries, grouped rich options, external filtering, stable active IDs, disabled items, and loading/empty states. Improve scroll-area composition and grouped option styling across the paired packages.
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kernelui-lib/react",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Accessible React components built on real semantic HTML, not div soup.",
   "license": "MIT",
   "author": "Karl Koch",


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? -->

## Checklist

- [ ] Both `@kernelui-lib/react` and `@kernelui-lib/elements` updated when applicable
- [ ] `bun run typecheck` passes
- [ ] `bun run build` passes for changed packages
- [ ] Docs page, demo, and playground added or updated when applicable
- [ ] Changeset added for publishable package changes (`bunx changeset`), or this PR is docs-only/non-publishable
- [ ] You can explain the change and stand behind it (LLM-assisted work is fine; untested spam is not)
