### PR TITLE
fix(cli): emit the bundled catalog as .cjs so it can actually load

### DIFF
--- a/.changeset/cli-registry-bundle-esm.md
+++ b/.changeset/cli-registry-bundle-esm.md
@@ -1,0 +1,19 @@
+---
+"@kernelui-lib/cli": patch
+---
+
+Fix the bundled component catalog failing to load, which left every CLI
+lookup empty.
+
+`bundle-registry.mjs` wrote CommonJS into `dist/registry-bundle.js`, but the
+package is `"type": "module"`, so Node parsed that file as ESM and threw
+`ReferenceError: exports is not defined in ES module scope` on load. The
+bundle is now emitted as `dist/registry-bundle.cjs`, where the extension
+says what the contents actually are.
+
+The reason a completely unloadable catalog shipped as a passing build: the
+`require` was wrapped in a `try/catch` that substituted an empty registry on
+any error. The ReferenceError was swallowed, so `kernel docs <name>`,
+`kernel init`, and every other lookup silently found nothing instead of
+crashing. That fallback is gone — a missing catalog now throws at load with
+a message saying it's a packaging fault worth reporting.

--- a/packages/cli/scripts/bundle-registry.mjs
+++ b/packages/cli/scripts/bundle-registry.mjs
@@ -66,19 +66,23 @@ exports.getComponentBySlug = function (slug) {
 // ── 4. Write to dist/ ───────────────────────────────────────────────────
 mkdirSync(outDir, { recursive: true });
 writeFileSync(join(outDir, "registry-bundle.d.ts"), dtsContent);
-writeFileSync(join(outDir, "registry-bundle.js"), jsContent);
+// `.cjs`, NOT `.js`: this package is "type": "module", so Node reads a bare
+// `.js` here as ESM and the CommonJS body below dies on `exports is not
+// defined` the moment anything loads it. The extension is the only thing
+// that says "this file really is CommonJS".
+writeFileSync(join(outDir, "registry-bundle.cjs"), jsContent);
 
 // Also emit .d.ts and a thin re-export .js into src/lib/ so TypeScript
 // can resolve `from "./registry-bundle.js"` during typecheck.
 const srcLibDir = join(__dirname, "..", "src", "lib");
 mkdirSync(srcLibDir, { recursive: true });
 writeFileSync(join(srcLibDir, "registry-bundle.d.ts"), dtsContent);
-// The JS file is an ESM shim that re-exports from the dist output.
-// At compile time this resolves types; at runtime tsc emits it as-is
-// and node loads the bundled data from dist.
+// An ESM shim so TypeScript can resolve the module during typecheck. It is
+// NOT emitted to dist (tsc doesn't copy .js without allowJs) and nothing
+// loads it at runtime — registry.ts requires the .cjs directly.
 writeFileSync(
   join(srcLibDir, "registry-bundle.js"),
-  `export { components, getComponentBySlug } from "../dist/registry-bundle.js";`,
+  `export { components, getComponentBySlug } from "../dist/registry-bundle.cjs";`,
 );
 
 console.log(`[bundle-registry] Bundled ${components.length} components → dist/registry-bundle.*`);

--- a/packages/cli/src/lib/registry-bundle.js
+++ b/packages/cli/src/lib/registry-bundle.js
@@ -1,1 +1,1 @@
-export { components, getComponentBySlug } from "../dist/registry-bundle.js";
+export { components, getComponentBySlug } from "../dist/registry-bundle.cjs";

--- a/packages/cli/src/lib/registry.ts
+++ b/packages/cli/src/lib/registry.ts
@@ -29,14 +29,26 @@ export interface RegistryEntry {
 import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 
-// Try the bundled ESM output first, then fall back to CJS.
+/* `.cjs` because the generated bundle is CommonJS and this package is
+   "type": "module" — a bare `.js` would be parsed as ESM and throw.
+
+   The catch deliberately does NOT substitute empty data any more. It used
+   to, and that is exactly how a bundle that could not be loaded at all
+   shipped as a working build: the ReferenceError was swallowed, every
+   lookup quietly returned undefined, and the CLI looked merely unhelpful
+   rather than broken. A missing catalog is not a recoverable state for a
+   CLI whose whole job is looking components up — fail loudly, at load. */
 let registryModule;
 try {
   // eslint-disable-next-line @typescript-eslint/no-require-imports -- bundle-generated
-  registryModule = require("../registry-bundle.js");
-} catch {
-  // Fallback: if dist hasn't been built yet, provide empty data.
-  registryModule = { components: [], getComponentBySlug: () => undefined };
+  registryModule = require("../registry-bundle.cjs");
+} catch (error) {
+  throw new Error(
+    "[kernel] Component catalog missing or unloadable (dist/registry-bundle.cjs). " +
+      "This is a packaging fault, not a user error — please report it at " +
+      "https://github.com/kemiljk/kernel-ui/issues.",
+    { cause: error },
+  );
 }
 type Mod = { components: RegistryEntry[]; getComponentBySlug: (slug: string) => RegistryEntry | undefined };
 const mod = registryModule as Mod;


### PR DESCRIPTION
## The bug

`packages/cli` is `"type": "module"`, but `bundle-registry.mjs` wrote **CommonJS** into `dist/registry-bundle.js`. Node therefore parsed it as ESM and threw on load:

```
ReferenceError: exports is not defined in ES module scope
```

The extension is the only thing that says what the contents actually are, so the bundle is now emitted as `dist/registry-bundle.cjs`.

## Why it shipped green

The `require` in `src/lib/registry.ts` sat inside a `try/catch` that substituted an empty registry on any error:

```ts
} catch {
  registryModule = { components: [], getComponentBySlug: () => undefined };
}
```

So the `ReferenceError` was swallowed. `findComponent` returned `undefined` for every query and `kernel docs Dialog` reported nothing found rather than crashing — the CLI read as unhelpful rather than broken. The three `tests/registry.test.ts` cases were the only thing that noticed.

That fallback is removed. An unloadable catalog isn't a recoverable state for a CLI whose whole job is looking components up, so it now throws at load with a message identifying it as a packaging fault.

## Impact

CI has been failing on `main` since `bf13b76` (2026-08-12) for exactly this. The published `@kernelui-lib/cli@1.0.1` has a non-functional registry.

## Verification

Ran CI's own sequence locally:

| Step | Result |
|---|---|
| `build --filter '@kernelui-lib/*'` | pass |
| `registry build` + `check` | pass |
| `typecheck --filter '@kernelui-lib/*'` | pass |
| React tests | 110 passed |
| CLI tests | **10 passed** (was 3 failing) |

Plus a real smoke test against the built binary, which previously found nothing:

```
$ node packages/cli/dist/index.js docs Dialog
Dialog (dialog)
  showModal(): focus trap, top layer, and ::backdrop, free.
  Docs: https://www.kernelui.com/components/dialog/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)