### PR TITLE
fix(docs): stop reserving the copy-button column on touch devices

### DIFF
--- a/apps/docs/src/styles/global.css
+++ b/apps/docs/src/styles/global.css
@@ -2119,7 +2119,26 @@ dialog.mobile-nav-panel[data-side="left"] {
   margin: 0;
   padding: var(--kernel-space-4);
   overflow-x: auto;
-  max-inline-size: calc(100% - 3.75rem);
+}
+
+/* …but reserve that column ONLY where the button can actually turn up.
+   `.code-block-copy` is `opacity: 0` until `:hover` — which is itself
+   gated on `hover: hover` and `pointer: fine` below — or `:focus-within`.
+   On a phone none of that happens, so the strip was 3.75rem of dead
+   space held open for a control that never renders: 60px of a 277px
+   block, 22% of the width, and the reason code appeared to stop short of
+   its own container with a blank gutter beside it.
+
+   `:focus-within` can still reveal the button on a touch device driven by
+   a keyboard, where no space is reserved. That's fine rather than
+   overlooked: the button is a `variant="secondary"` Button, so it has an
+   opaque background and covers the character cells beneath it instead of
+   colliding with them. Reserving 22% of every code block on every phone
+   against that possibility is the worse trade. */
+@media (hover: hover) and (pointer: fine) {
+  .code-block pre {
+    max-inline-size: calc(100% - 3.75rem);
+  }
 }
 
 .code-block-copy {


### PR DESCRIPTION
Code blocks stopped short of their container on mobile, leaving a blank gutter down the right-hand side.

## Cause

`.code-block pre` was capped at `calc(100% - 3.75rem)` to keep code text from sitting under the floating copy button. But that button is `opacity: 0` until `:hover` — which is itself gated behind `hover: hover` and `pointer: fine` — or `:focus-within`. On a phone none of that fires, so the strip reserved 60px for a control that never renders.

On the homepage's cascade panel that was 60px of a 277px block: **22% of the width**, permanently dead.

## Fix

The reservation moves into the same media query that reveals the button, so the space is held open exactly where the button can appear.

| Viewport | Block | `pre` | Gap |
|---|---|---|---|
| 375px, before | 277px | 215px | **60px** |
| 375px, after | 277px | 275px | **2px** (border) |
| 1280px, after | 704px | 642px | 62px (unchanged) |

Verified across all six code blocks on the homepage at 375px — every one now within 2px of its container — and on `/installation/` at both widths.

## Trade-off

`:focus-within` can still reveal the button on a touch device driven by a keyboard, where no space is now reserved. Accepted rather than overlooked: the button is a `variant="secondary"` Button, so it has an opaque background and covers the characters beneath it rather than colliding with them. Reserving 22% of every code block on every phone against that case is the worse deal.

## Provenance

Pre-existing since `init` — not introduced by `4609935`. That commit moved the cascade sample into a wide, prominent panel, which is where the dead strip became obvious.

Docs-only, no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)